### PR TITLE
v0.2.0 Release 🚀

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,13 +7,13 @@ SERVER_ADDRESS="http://dank-server:3000"
 CDN_ADDRESS="http://localhost:20251"
 EVENTHUB_ADDRESS="http://dank-eventhub:3002"
 FRONTEND_ADDRESS="http://localhost:20253"
+YTDL_ADDRESS="http://localhost:4321"
 
 GO_ENV="dev" # "beta" "prod"
 HOST_NAME="http://localhost:3000"
 JWT_SECRET="spoikoninochi"
 
-YOUTUBE_DOWNLOADER_URL="http://localhost:4321"
-YOUTUBE_MUSIC_DOWNLOAD_PATH="/app/.serve/"
+BLOBS_DIR="/app/.serve/"
 
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""

--- a/docker-compose-all.yml
+++ b/docker-compose-all.yml
@@ -10,6 +10,8 @@ services:
     stdin_open: true
     env_file:
       - .env.docker
+    volumes:
+      - dank-files:/app/.serve
     networks:
       - danknetwork
     depends_on:

--- a/docker-compose-all.yml
+++ b/docker-compose-all.yml
@@ -62,6 +62,8 @@ services:
     stdin_open: true
     env_file:
       - .env.docker
+    volumes:
+      - dank-files:/app/.serve
     networks:
       - danknetwork
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     stdin_open: true
     env_file:
       - .env.docker
+    volumes:
+      - dank-files:/app/.serve
     networks:
       - danknetwork
 

--- a/infrastructure/docker-compose/main.go
+++ b/infrastructure/docker-compose/main.go
@@ -312,8 +312,13 @@ func generateComposeFile(values TemplateValues) (string, error) {
 		},
 		Environment: []ServiceEnvironmentValues{},
 		EnvFile:     ".env.docker",
-		Volumes:     []ServiceVolumesValues{},
-		Networks:    []string{values.NetworkName},
+		Volumes: []ServiceVolumesValues{
+			{
+				VolumeName: filesVolumeName,
+				MountPath:  "/app/.serve",
+			},
+		},
+		Networks: []string{values.NetworkName},
 	})
 	if err != nil {
 		return "", err

--- a/infrastructure/docker-compose/main.go
+++ b/infrastructure/docker-compose/main.go
@@ -234,9 +234,14 @@ func generateComposeFile(values TemplateValues) (string, error) {
 		},
 		Environment: []ServiceEnvironmentValues{},
 		EnvFile:     ".env.docker",
-		Volumes:     []ServiceVolumesValues{},
-		Networks:    []string{values.NetworkName},
-		DependsOn:   []string{cdnContainerName, ytdlContainerName, eventhubContainerName},
+		Volumes: []ServiceVolumesValues{
+			{
+				VolumeName: filesVolumeName,
+				MountPath:  "/app/.serve",
+			},
+		},
+		Networks:  []string{values.NetworkName},
+		DependsOn: []string{cdnContainerName, ytdlContainerName, eventhubContainerName},
 	})
 	if err != nil {
 		return "", err

--- a/infrastructure/docker-compose/main.go
+++ b/infrastructure/docker-compose/main.go
@@ -236,7 +236,7 @@ func generateComposeFile(values TemplateValues) (string, error) {
 		EnvFile:     ".env.docker",
 		Volumes:     []ServiceVolumesValues{},
 		Networks:    []string{values.NetworkName},
-		DependsOn:   []string{"dank-cdn", "dank-ytdl", "dank-eventhub"},
+		DependsOn:   []string{cdnContainerName, ytdlContainerName, eventhubContainerName},
 	})
 	if err != nil {
 		return "", err
@@ -259,7 +259,7 @@ func generateComposeFile(values TemplateValues) (string, error) {
 		EnvFile:     ".env.docker",
 		Volumes:     []ServiceVolumesValues{},
 		Networks:    []string{values.NetworkName},
-		DependsOn:   []string{"dank-server"},
+		DependsOn:   []string{serverContainerName},
 	})
 	if err != nil {
 		return "", err

--- a/infrastructure/nginx/dankmuzikk-beta.conf
+++ b/infrastructure/nginx/dankmuzikk-beta.conf
@@ -26,6 +26,20 @@ server {
         proxy_pass $upstream/$1$is_args$args;
     }
 
+    location ~ ^/pix(.*)$ {
+        set $upstream http://127.0.0.1:20361/pix;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass_request_headers      on;
+        proxy_pass $upstream/$1$is_args$args;
+    }
+
+    location ~ ^/playlists/zip(.*)$ {
+        set $upstream http://127.0.0.1:20361/playlists/zip;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass_request_headers      on;
+        proxy_pass $upstream/$1$is_args$args;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:20361;
     }

--- a/infrastructure/nginx/dankmuzikk-beta.conf
+++ b/infrastructure/nginx/dankmuzikk-beta.conf
@@ -5,9 +5,9 @@ server {
 
     location ~ ^/muzikkx(.*)$ {
         set $upstream http://127.0.0.1:20361/muzikkx;
-        proxy_read_timeout 1800;
-        proxy_connect_timeout 1800;
-        proxy_send_timeout 1800;
+        proxy_read_timeout 300;
+        proxy_connect_timeout 300;
+        proxy_send_timeout 300;
         # required headers for safari :)
         proxy_set_header Connection "keep-alive";
         proxy_set_header Range "bytes=0-";
@@ -16,8 +16,11 @@ server {
         proxy_pass $upstream$1$is_args$args;
     }
 
-    location ~ ^/(.*)$ {
-        set $upstream http://127.0.0.1:20361;
+    location ~ ^/muzikkx-raw(.*)$ {
+        set $upstream http://127.0.0.1:20361/muzikkx-raw;
+        proxy_read_timeout 300;
+        proxy_connect_timeout 300;
+        proxy_send_timeout 300;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass_request_headers      on;
         proxy_pass $upstream/$1$is_args$args;
@@ -35,9 +38,9 @@ server {
 
     location ~ ^/(.*)$ {
         set $upstream http://127.0.0.1:20363;
-        proxy_read_timeout 180;
-        proxy_connect_timeout 180;
-        proxy_send_timeout 180;
+        proxy_read_timeout 20;
+        proxy_connect_timeout 20;
+        proxy_send_timeout 20;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass_request_headers      on;
         proxy_pass $upstream/$1$is_args$args;
@@ -55,9 +58,9 @@ server {
 
     location ~ ^/(.*)$ {
         set $upstream http://127.0.0.1:20360;
-        proxy_read_timeout 180;
-        proxy_connect_timeout 180;
-        proxy_send_timeout 180;
+        proxy_read_timeout 20;
+        proxy_connect_timeout 20;
+        proxy_send_timeout 20;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass_request_headers      on;
         proxy_pass $upstream/$1$is_args$args;

--- a/infrastructure/nginx/dankmuzikk.conf
+++ b/infrastructure/nginx/dankmuzikk.conf
@@ -26,6 +26,20 @@ server {
         proxy_pass $upstream/$1$is_args$args;
     }
 
+    location ~ ^/pix(.*)$ {
+        set $upstream http://127.0.0.1:20251/pix;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass_request_headers      on;
+        proxy_pass $upstream/$1$is_args$args;
+    }
+
+    location ~ ^/playlists/zip(.*)$ {
+        set $upstream http://127.0.0.1:20251/playlists/zip;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass_request_headers      on;
+        proxy_pass $upstream/$1$is_args$args;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:20251;
     }

--- a/infrastructure/nginx/dankmuzikk.conf
+++ b/infrastructure/nginx/dankmuzikk.conf
@@ -4,10 +4,10 @@ server {
     server_name cdn.dankmuzikk.com;
 
     location ~ ^/muzikkx(.*)$ {
-        set $upstream http://127.0.0.1:20351/muzikkx;
-        proxy_read_timeout 1800;
-        proxy_connect_timeout 1800;
-        proxy_send_timeout 1800;
+        set $upstream http://127.0.0.1:20251/muzikkx;
+        proxy_read_timeout 300;
+        proxy_connect_timeout 300;
+        proxy_send_timeout 300;
         # required headers for safari :)
         proxy_set_header Connection "keep-alive";
         proxy_set_header Range "bytes=0-";
@@ -16,15 +16,18 @@ server {
         proxy_pass $upstream$1$is_args$args;
     }
 
-    location ~ ^/(.*)$ {
-        set $upstream http://127.0.0.1:20351;
+    location ~ ^/muzikkx-raw(.*)$ {
+        set $upstream http://127.0.0.1:20251/muzikkx-raw;
+        proxy_read_timeout 300;
+        proxy_connect_timeout 300;
+        proxy_send_timeout 300;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass_request_headers      on;
         proxy_pass $upstream/$1$is_args$args;
     }
 
     location / {
-        proxy_pass http://127.0.0.1:20351;
+        proxy_pass http://127.0.0.1:20251;
     }
 }
 
@@ -34,17 +37,17 @@ server {
     server_name dankmuzikk.com;
 
     location ~ ^/(.*)$ {
-        set $upstream http://127.0.0.1:20353;
-        proxy_read_timeout 180;
-        proxy_connect_timeout 180;
-        proxy_send_timeout 180;
+        set $upstream http://127.0.0.1:20253;
+        proxy_read_timeout 20;
+        proxy_connect_timeout 20;
+        proxy_send_timeout 20;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass_request_headers      on;
         proxy_pass $upstream/$1$is_args$args;
     }
 
     location / {
-        proxy_pass http://127.0.0.1:20353;
+        proxy_pass http://127.0.0.1:20253;
     }
 }
 
@@ -54,16 +57,16 @@ server {
     server_name api.dankmuzikk.com;
 
     location ~ ^/(.*)$ {
-        set $upstream http://127.0.0.1:20350;
-        proxy_read_timeout 180;
-        proxy_connect_timeout 180;
-        proxy_send_timeout 180;
+        set $upstream http://127.0.0.1:20250;
+        proxy_read_timeout 20;
+        proxy_connect_timeout 20;
+        proxy_send_timeout 20;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass_request_headers      on;
         proxy_pass $upstream/$1$is_args$args;
     }
 
     location / {
-        proxy_pass http://127.0.0.1:20350;
+        proxy_pass http://127.0.0.1:20250;
     }
 }

--- a/server/actions/actions.go
+++ b/server/actions/actions.go
@@ -3,28 +3,31 @@ package actions
 import "dankmuzikk/app"
 
 type Actions struct {
-	app      *app.App
-	eventhub EventHub
-	archiver Archiver
-	jwt      JwtManager[TokenPayload]
-	mailer   Mailer
-	youtube  YouTube
+	app         *app.App
+	eventhub    EventHub
+	archiver    Archiver
+	blobstorage BlobStorage
+	jwt         JwtManager[TokenPayload]
+	mailer      Mailer
+	youtube     YouTube
 }
 
 func New(
 	app *app.App,
 	eventhub EventHub,
 	archiver Archiver,
+	blobstorage BlobStorage,
 	jwt JwtManager[TokenPayload],
 	mailer Mailer,
 	youtube YouTube,
 ) *Actions {
 	return &Actions{
-		app:      app,
-		eventhub: eventhub,
-		archiver: archiver,
-		jwt:      jwt,
-		mailer:   mailer,
-		youtube:  youtube,
+		app:         app,
+		eventhub:    eventhub,
+		archiver:    archiver,
+		blobstorage: blobstorage,
+		jwt:         jwt,
+		mailer:      mailer,
+		youtube:     youtube,
 	}
 }

--- a/server/actions/blobstorage.go
+++ b/server/actions/blobstorage.go
@@ -1,0 +1,22 @@
+package actions
+
+import (
+	"io"
+	"os"
+)
+
+// BlobStorage encapsulates files operations.
+type BlobStorage interface {
+	// CreateFile creates a file in the given path.
+	CreateFile(path string) error
+	// GetFile returns an io.ReadCloser of the given file path.
+	GetFile(path string) (*os.File, error)
+	// WriteToFile overrides the file's content at the given path.
+	WriteToFile(path string, content io.Reader) error
+	// CopyFile copies the given file to the new path.
+	CopyFile(oldPath, newPath string) error
+	// MoveFile moves the given file to the new path.
+	MoveFile(oldPath, newPath string) error
+	// DeleteFile deletes the given file.
+	DeleteFile(path string) error
+}

--- a/server/actions/playlist.go
+++ b/server/actions/playlist.go
@@ -98,13 +98,13 @@ func (a *Actions) DownloadPlaylist(playlistPubId string, profileId uint) (io.Rea
 
 	fileNames := make([]string, 0, playlist.SongsCount)
 	for i, song := range playlist.Songs {
-		ogFile, err := os.Open(fmt.Sprintf("%s/%s.mp3", config.Env().YouTube.MuzikkDir, song.YtId))
+		ogFile, err := os.Open(fmt.Sprintf("%s/muzikkx/%s.mp3", config.Env().BlobsDir, song.YtId))
 		if err != nil {
 			return nil, err
 		}
 		newShit, err := os.OpenFile(
 			filepath.Clean(
-				fmt.Sprintf("%s/%d-%s.mp3", config.Env().YouTube.MuzikkDir, i+1,
+				fmt.Sprintf("%s/muzikkx/%d-%s.mp3", config.Env().BlobsDir, i+1,
 					strings.ReplaceAll(song.Title, "/", "|"),
 				),
 			),

--- a/server/actions/song.go
+++ b/server/actions/song.go
@@ -167,7 +167,7 @@ func (a *Actions) PlaySong(params PlaySongParams) (mediaUrl string, err error) {
 
 func (a *Actions) SaveSongsMetadataFromYouTube(songs []Song) error {
 	for _, newSong := range songs {
-		_, err := a.app.CreateSong(models.Song{
+		_, _ = a.app.CreateSong(models.Song{
 			YtId:            newSong.YtId,
 			Title:           newSong.Title,
 			Artist:          newSong.Artist,
@@ -175,9 +175,6 @@ func (a *Actions) SaveSongsMetadataFromYouTube(songs []Song) error {
 			Duration:        newSong.Duration,
 			FullyDownloaded: false,
 		})
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/server/actions/song.go
+++ b/server/actions/song.go
@@ -40,7 +40,7 @@ func (a *Actions) GetSongByYouTubeId(ytId string) (Song, error) {
 					YtId:            s.YtId,
 					Title:           s.Title,
 					Artist:          s.Artist,
-					ThumbnailUrl:    s.ThumbnailUrl,
+					ThumbnailUrl:    fmt.Sprintf("%s/pix/%s.webp", config.CdnAddress(), s.YtId),
 					Duration:        s.Duration,
 					FullyDownloaded: false,
 				}
@@ -171,7 +171,7 @@ func (a *Actions) SaveSongsMetadataFromYouTube(songs []Song) error {
 			YtId:            newSong.YtId,
 			Title:           newSong.Title,
 			Artist:          newSong.Artist,
-			ThumbnailUrl:    newSong.ThumbnailUrl,
+			ThumbnailUrl:    fmt.Sprintf("%s/pix/%s.webp", config.CdnAddress(), newSong.YtId),
 			Duration:        newSong.Duration,
 			FullyDownloaded: false,
 		})

--- a/server/blobs/blobs.go
+++ b/server/blobs/blobs.go
@@ -1,0 +1,92 @@
+package blobs
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type Blobs struct{}
+
+func New() *Blobs {
+	return &Blobs{}
+}
+
+func (b *Blobs) CreateFile(path string) error {
+	file, err := os.Create(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+
+	err = file.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *Blobs) GetFile(path string) (*os.File, error) {
+	return os.Open(filepath.Clean(path))
+}
+
+func (b *Blobs) WriteToFile(path string, content io.Reader) error {
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(file, content)
+	if err != nil {
+		return err
+	}
+
+	err = file.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *Blobs) CopyFile(oldPath, newPath string) error {
+	oldFile, err := os.Open(filepath.Clean(oldPath))
+	if err != nil {
+		return err
+	}
+
+	newFile, err := os.Create(filepath.Clean(newPath))
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(newFile, oldFile)
+	if err != nil {
+		return err
+	}
+
+	err = oldFile.Close()
+	if err != nil {
+		return err
+	}
+
+	err = newFile.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *Blobs) MoveFile(oldPath, newPath string) error {
+	err := b.CopyFile(oldPath, newPath)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(filepath.Clean(oldPath))
+}
+
+func (b *Blobs) DeleteFile(path string) error {
+	return os.Remove(filepath.Clean(path))
+}

--- a/server/cmd/cdn/main.go
+++ b/server/cmd/cdn/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	applicationHandler.Handle("/muzikkx/", http.StripPrefix("/muzikkx", http.FileServer(http.Dir(muzikkxDir))))
 	applicationHandler.Handle("/muzikkx-raw/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/muzikkx/"), ".mp3")
+		id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/muzikkx-raw/"), ".mp3")
 		song, err := mariadbRepo.GetSongByYouTubeId(id)
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)

--- a/server/cmd/cdn/main.go
+++ b/server/cmd/cdn/main.go
@@ -37,7 +37,14 @@ func main() {
 
 	applicationHandler.Handle("/muzikkx/", http.StripPrefix("/muzikkx", http.FileServer(http.Dir(muzikkxDir))))
 	applicationHandler.Handle("/muzikkx-raw/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Disposition", "attachment")
+		id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/muzikkx/"), ".mp3")
+		song, err := mariadbRepo.GetSongByYouTubeId(id)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Disposition", "attachment; filename="+song.Title+".mp3")
 		http.
 			StripPrefix("/muzikkx-raw", http.FileServer(http.Dir(muzikkxDir))).
 			ServeHTTP(w, r)
@@ -58,7 +65,6 @@ func main() {
 		}
 
 		w.Header().Set("Content-Disposition", "attachment; filename="+pl.Title+".zip")
-
 		http.
 			StripPrefix("/playlists", http.FileServer(http.Dir(playlistsDir))).
 			ServeHTTP(w, r)

--- a/server/cmd/cdn/main.go
+++ b/server/cmd/cdn/main.go
@@ -44,6 +44,7 @@ func main() {
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Disposition", "attachment; filename*=UTF-8''"+song.Title+".mp3")
 		http.
 			StripPrefix("/muzikkx-raw", http.FileServer(http.Dir(muzikkxDir))).
@@ -64,6 +65,7 @@ func main() {
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Disposition", "attachment; filename*=UTF-8''"+pl.Title+".zip")
 		http.
 			StripPrefix("/playlists", http.FileServer(http.Dir(playlistsDir))).

--- a/server/cmd/cdn/main.go
+++ b/server/cmd/cdn/main.go
@@ -31,13 +31,18 @@ func StartServer() error {
 	// authMw := auth.New(usecases)
 	// applicationHandler.Handle("/muzikkx/", authMw.AuthHandler(http.StripPrefix("/muzikkx", http.FileServer(http.Dir(config.Env().YouTube.MuzikkDir)))))
 	applicationHandler := http.NewServeMux()
-	applicationHandler.Handle("/muzikkx/", http.StripPrefix("/muzikkx", http.FileServer(http.Dir(config.Env().YouTube.MuzikkDir))))
+
+	muzikkxDir := config.Env().BlobsDir + "/muzikkx/"
+	pixDir := config.Env().BlobsDir + "/pix/"
+
+	applicationHandler.Handle("/muzikkx/", http.StripPrefix("/muzikkx", http.FileServer(http.Dir(muzikkxDir))))
 	applicationHandler.Handle("/muzikkx-raw/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Disposition", "attachment")
 		http.
-			StripPrefix("/muzikkx-raw", http.FileServer(http.Dir(config.Env().YouTube.MuzikkDir))).
+			StripPrefix("/muzikkx-raw", http.FileServer(http.Dir(muzikkxDir))).
 			ServeHTTP(w, r)
 	}))
+	applicationHandler.Handle("/pix/", http.StripPrefix("/pix", http.FileServer(http.Dir(pixDir))))
 
 	log.Info("Starting http cdn server at port " + config.Env().CdnPort)
 	if config.Env().GoEnv == "dev" || config.Env().GoEnv == "beta" {

--- a/server/cmd/cdn/main.go
+++ b/server/cmd/cdn/main.go
@@ -64,7 +64,7 @@ func main() {
 			return
 		}
 
-		w.Header().Set("Content-Disposition", "attachment; filename="+pl.Title+".zip")
+		w.Header().Set("Content-Disposition", "attachment; filename*=UTF-8''"+pl.Title+".zip")
 		http.
 			StripPrefix("/playlists", http.FileServer(http.Dir(playlistsDir))).
 			ServeHTTP(w, r)

--- a/server/cmd/cdn/main.go
+++ b/server/cmd/cdn/main.go
@@ -2,38 +2,38 @@ package main
 
 import (
 	"dankmuzikk/config"
+	"dankmuzikk/evy"
+	"dankmuzikk/evy/events"
 	"dankmuzikk/handlers/middlewares/logger"
 	"dankmuzikk/log"
+	"dankmuzikk/mariadb"
 	"net/http"
+	"strings"
+	"time"
 )
 
 func main() {
-	err := StartServer()
+	mariadbRepo, err := mariadb.New()
 	if err != nil {
 		log.Fatalln(err)
 	}
-}
-
-func StartServer() error {
-	// mariadbRepo, err := mariadb.New()
-	// if err != nil {
-	// return err
-	// }
 	// app := app.New(mariadbRepo)
+	eventhub := evy.New()
 	// jwtUtil := jwt.New[actions.TokenPayload]()
-	//	usecases := actions.New(
-	//		app,
-	//		nil,
-	//		jwtUtil,
-	//		nil,
-	//		nil,
-	//	)
+	// usecases := actions.New(
+	// 	app,
+	// 	eventhub,
+	// 	nil,
+	// 	jwtUtil,
+	// 	nil,
+	// 	nil,
+	// )
 	// authMw := auth.New(usecases)
-	// applicationHandler.Handle("/muzikkx/", authMw.AuthHandler(http.StripPrefix("/muzikkx", http.FileServer(http.Dir(config.Env().YouTube.MuzikkDir)))))
 	applicationHandler := http.NewServeMux()
 
 	muzikkxDir := config.Env().BlobsDir + "/muzikkx/"
 	pixDir := config.Env().BlobsDir + "/pix/"
+	playlistsDir := config.Env().BlobsDir + "/playlists/"
 
 	applicationHandler.Handle("/muzikkx/", http.StripPrefix("/muzikkx", http.FileServer(http.Dir(muzikkxDir))))
 	applicationHandler.Handle("/muzikkx-raw/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,11 +42,31 @@ func StartServer() error {
 			StripPrefix("/muzikkx-raw", http.FileServer(http.Dir(muzikkxDir))).
 			ServeHTTP(w, r)
 	}))
+
 	applicationHandler.Handle("/pix/", http.StripPrefix("/pix", http.FileServer(http.Dir(pixDir))))
+	applicationHandler.Handle("/playlists/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/playlists/"), ".zip")
+		eventhub.Publish(events.PlaylistDownloaded{
+			PlaylistId: id,
+			DeleteAt:   time.Now().Add(time.Hour),
+		})
+
+		pl, err := mariadbRepo.GetPlaylistByPublicId(id)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Disposition", "attachment; filename="+pl.Title+".zip")
+
+		http.
+			StripPrefix("/playlists", http.FileServer(http.Dir(playlistsDir))).
+			ServeHTTP(w, r)
+	}))
 
 	log.Info("Starting http cdn server at port " + config.Env().CdnPort)
 	if config.Env().GoEnv == "dev" || config.Env().GoEnv == "beta" {
-		return http.ListenAndServe(":"+config.Env().CdnPort, logger.Handler(applicationHandler))
+		log.Fatalln(http.ListenAndServe(":"+config.Env().CdnPort, logger.Handler(applicationHandler)))
 	}
-	return http.ListenAndServe(":"+config.Env().CdnPort, applicationHandler)
+	log.Fatalln(http.ListenAndServe(":"+config.Env().CdnPort, applicationHandler))
 }

--- a/server/cmd/cdn/main.go
+++ b/server/cmd/cdn/main.go
@@ -44,7 +44,7 @@ func main() {
 			return
 		}
 
-		w.Header().Set("Content-Disposition", "attachment; filename="+song.Title+".mp3")
+		w.Header().Set("Content-Disposition", "attachment; filename*=UTF-8''"+song.Title+".mp3")
 		http.
 			StripPrefix("/muzikkx-raw", http.FileServer(http.Dir(muzikkxDir))).
 			ServeHTTP(w, r)

--- a/server/cmd/eventhub/eventhub.go
+++ b/server/cmd/eventhub/eventhub.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	eventsBatchItems     = 25
-	fetchWaitTimeSeconds = 5
+	fetchWaitTimeSeconds = 1
 )
 
 var (

--- a/server/cmd/eventhub/eventhub.go
+++ b/server/cmd/eventhub/eventhub.go
@@ -133,6 +133,22 @@ func executeEvents(events []evy.EventPayload) error {
 
 				wg.Done()
 			}()
+		case "playlist-downloaded":
+			var body dankevents.PlaylistDownloaded
+			err := json.Unmarshal([]byte(e.Body), &body)
+			if err != nil {
+				log.Errorf("failed unmarshalling event's json: %v\n", err)
+				continue
+			}
+
+			go func() {
+				err := handlers.HandleDownloadPlaylist(body)
+				if err != nil {
+					log.Errorln("playlist-downloaded", err)
+				}
+
+				wg.Done()
+			}()
 		}
 		err := repo.DeleteEvent(e.Id)
 		if err != nil {

--- a/server/cmd/eventhub/main.go
+++ b/server/cmd/eventhub/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"dankmuzikk/actions"
 	"dankmuzikk/app"
+	"dankmuzikk/blobs"
 	"dankmuzikk/config"
 	"dankmuzikk/handlers/events"
 	"dankmuzikk/jwt"
@@ -24,6 +25,7 @@ func init() {
 
 	app := app.New(mariadbRepo)
 	zipArchiver := zip.New()
+	blobstorage := blobs.New()
 	jwtUtil := jwt.New[actions.TokenPayload]()
 	mailer := mailer.New()
 	yt := youtube.New()
@@ -32,6 +34,7 @@ func init() {
 		app,
 		&eventHub{},
 		zipArchiver,
+		blobstorage,
 		jwtUtil,
 		mailer,
 		yt,

--- a/server/cmd/http-server/main.go
+++ b/server/cmd/http-server/main.go
@@ -93,7 +93,6 @@ func StartServer() error {
 	v1ApisHandler.HandleFunc("GET /profile", userApi.HandleGetProfile)
 
 	pagesHandler := http.NewServeMux()
-	pagesHandler.Handle("/muzikkx/", http.StripPrefix("/muzikkx", http.FileServer(http.Dir(config.Env().YouTube.MuzikkDir))))
 
 	applicationHandler := http.NewServeMux()
 	applicationHandler.Handle("/", pagesHandler)

--- a/server/cmd/http-server/main.go
+++ b/server/cmd/http-server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"dankmuzikk/actions"
 	"dankmuzikk/app"
+	"dankmuzikk/blobs"
 	"dankmuzikk/config"
 	"dankmuzikk/evy"
 	"dankmuzikk/handlers/apis"
@@ -40,6 +41,7 @@ func StartServer() error {
 	app := app.New(mariadbRepo)
 	eventhub := evy.New()
 	zipArchiver := zip.New()
+	blobstorage := blobs.New()
 	jwtUtil := jwt.New[actions.TokenPayload]()
 	mailer := mailer.New()
 	yt := youtube.New()
@@ -48,6 +50,7 @@ func StartServer() error {
 		app,
 		eventhub,
 		zipArchiver,
+		blobstorage,
 		jwtUtil,
 		mailer,
 		yt,

--- a/server/config/env.go
+++ b/server/config/env.go
@@ -11,22 +11,17 @@ var (
 
 func initEnvVars() {
 	_config = config{
-		Port:            getEnv("PORT"),
-		CdnPort:         getEnv("CDN_PORT"),
-		EventHubPort:    getEnv("EVENTHUB_PORT"),
-		WebPort:         getEnv("WEB_PORT"),
-		GoEnv:           getEnv("GO_ENV"),
-		CdnAddress:      getEnv("CDN_ADDRESS"),
-		EventHubAddress: getEnv("EVENTHUB_ADDRESS"),
-		Hostname:        getEnv("HOST_NAME"),
-		JwtSecret:       getEnv("JWT_SECRET"),
-		YouTube: struct {
-			DownloaderUrl string
-			MuzikkDir     string
-		}{
-			DownloaderUrl: getEnv("YOUTUBE_DOWNLOADER_URL"),
-			MuzikkDir:     getEnv("YOUTUBE_MUSIC_DOWNLOAD_PATH"),
-		},
+		Port:                     getEnv("PORT"),
+		CdnPort:                  getEnv("CDN_PORT"),
+		EventHubPort:             getEnv("EVENTHUB_PORT"),
+		WebPort:                  getEnv("WEB_PORT"),
+		GoEnv:                    getEnv("GO_ENV"),
+		CdnAddress:               getEnv("CDN_ADDRESS"),
+		EventHubAddress:          getEnv("EVENTHUB_ADDRESS"),
+		YouTubeDownloaderAddress: getEnv("YTDL_ADDRESS"),
+		Hostname:                 getEnv("HOST_NAME"),
+		JwtSecret:                getEnv("JWT_SECRET"),
+		BlobsDir:                 getEnv("BLOBS_DIR"),
 		Google: struct {
 			ClientId     string
 			ClientSecret string
@@ -60,20 +55,18 @@ func initEnvVars() {
 }
 
 type config struct {
-	Port            string
-	CdnPort         string
-	EventHubPort    string
-	WebPort         string
-	GoEnv           string
-	CdnAddress      string
-	EventHubAddress string
-	Hostname        string
-	JwtSecret       string
-	YouTube         struct {
-		DownloaderUrl string
-		MuzikkDir     string
-	}
-	Google struct {
+	Port                     string
+	CdnPort                  string
+	EventHubPort             string
+	WebPort                  string
+	GoEnv                    string
+	CdnAddress               string
+	EventHubAddress          string
+	YouTubeDownloaderAddress string
+	Hostname                 string
+	JwtSecret                string
+	BlobsDir                 string
+	Google                   struct {
 		ClientId     string
 		ClientSecret string
 	}
@@ -94,6 +87,15 @@ type config struct {
 // Env returns the thing's config values :)
 func Env() config {
 	return _config
+}
+
+func CdnAddress() string {
+	cdnAddress := "https://cdn.dankmuzikk.com"
+	if Env().GoEnv == "dev" {
+		cdnAddress = Env().CdnAddress
+	}
+
+	return cdnAddress
 }
 
 func getEnv(key string) string {

--- a/server/evy/events/playlist.go
+++ b/server/evy/events/playlist.go
@@ -1,0 +1,12 @@
+package events
+
+import "time"
+
+type PlaylistDownloaded struct {
+	PlaylistId string    `json:"playlist_id"`
+	DeleteAt   time.Time `json:"delete_at"`
+}
+
+func (p PlaylistDownloaded) Topic() string {
+	return "playlist-downloaded"
+}

--- a/server/handlers/apis/playlist.go
+++ b/server/handlers/apis/playlist.go
@@ -5,7 +5,6 @@ import (
 	"dankmuzikk/handlers/middlewares/auth"
 	"dankmuzikk/log"
 	"encoding/json"
-	"io"
 	"net/http"
 )
 
@@ -218,11 +217,14 @@ func (p *playlistApi) HandleDonwnloadPlaylist(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	playlistZip, err := p.usecases.DownloadPlaylist(playlistId, profileId)
+	playlistDownloadUrl, err := p.usecases.DownloadPlaylist(playlistId, profileId)
 	if err != nil {
 		log.Error(err)
 		handleErrorResponse(w, err)
 		return
 	}
-	_, _ = io.Copy(w, playlistZip)
+
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"playlist_download_url": playlistDownloadUrl,
+	})
 }

--- a/server/handlers/events/events.go
+++ b/server/handlers/events/events.go
@@ -58,4 +58,8 @@ func (e *EventHandlers) HandleSaveSongsMetadataOnSearchBatch(event events.SongsS
 	return e.usecases.SaveSongsMetadataFromYouTube(songs)
 }
 
+func (e *EventHandlers) HandleDownloadPlaylist(event events.PlaylistDownloaded) error {
+	return e.usecases.DeletePlaylistArchive(event)
+}
+
 func (e *EventHandlers) IncrementSongPlaysInPlaylist() {}

--- a/server/youtube/youtube.go
+++ b/server/youtube/youtube.go
@@ -230,12 +230,12 @@ func (y *YouTube) SearchSuggestions(query string) (suggestions []string, err err
 }
 
 // DownloadYoutubeSong downloads a YouTube muzikk file into the path specified by the environment variable
-// YOUTUBE_MUSIC_DOWNLOAD_PATH, where the file name will be <video_id.mp3> to be served under /muzikk/{id}
+// BLOBS_DIR, where the file name will be <video_id.mp3> to be served under /muzikk/{id}
 // and returns an occurring error
 //
 // Used when playing a new song (usually from search).
 func (y *YouTube) DownloadYoutubeSong(songYtId string) error {
-	resp, err := http.Get(fmt.Sprintf("%s/download/%s", config.Env().YouTube.DownloaderUrl, songYtId))
+	resp, err := http.Get(fmt.Sprintf("%s/download/%s", config.Env().YouTubeDownloaderAddress, songYtId))
 	if err != nil {
 		return err
 	}

--- a/web/handlers/apis/playlist.go
+++ b/web/handlers/apis/playlist.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"context"
-	"dankmuzikk-web/config"
 	"dankmuzikk-web/entities"
 	"dankmuzikk-web/handlers/middlewares/auth"
 	"dankmuzikk-web/log"
@@ -13,9 +12,7 @@ import (
 	"dankmuzikk-web/views/icons"
 	"dankmuzikk-web/views/pages"
 	"encoding/json"
-	"io"
 	"net/http"
-	"time"
 )
 
 type playlistApi struct {
@@ -269,25 +266,14 @@ func (p *playlistApi) HandleDonwnloadPlaylist(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	req, err := http.NewRequest(http.MethodGet, config.GetRequestUrl("/v1/playlist/zip"), http.NoBody)
+	playlistDownloadUrl, err := p.service.DownloadPlaylist(sessionToken.Value, playlistId)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("🤷‍♂️"))
 		return
 	}
 
-	req.Header.Set("Authorization", sessionToken.Value)
-
-	resp, err := (&http.Client{Timeout: time.Second * 20}).Do(req)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	_, _ = io.Copy(w, resp.Body)
-	_ = resp.Body.Close()
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"playlist_download_url": playlistDownloadUrl,
+	})
 }

--- a/web/services/playlists/playlists.go
+++ b/web/services/playlists/playlists.go
@@ -3,8 +3,10 @@ package playlists
 import (
 	"dankmuzikk-web/entities"
 	"dankmuzikk-web/services/requests"
+	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -71,4 +73,18 @@ func (p *Service) GetAllMappedForAddPopover(token string) ([]entities.Playlist, 
 	}
 
 	return resp.Playlists, resp.SongsInPlaylists, nil
+}
+
+func (p *Service) DownloadPlaylist(token, playlistId string) (string, error) {
+	resp, err := requests.GetRequestAuth[map[string]string](fmt.Sprintf("/v1/playlist/zip?playlist-id=%s", url.QueryEscape(playlistId)), token)
+	if err != nil {
+		return "", err
+	}
+
+	playlistDownloadUrl, ok := resp["playlist_download_url"]
+	if !ok {
+		return "", errors.New("missing playlist_download_url")
+	}
+
+	return playlistDownloadUrl, err
 }

--- a/web/static/js/player.js
+++ b/web/static/js/player.js
@@ -566,13 +566,14 @@ async function downloadPlaylistToDevice(plPubId, plTitle) {
       if (!res.ok) {
         throw new Error(await res.text());
       }
-      return res.blob();
+      return res.json();
     })
-    .then((playlistZip) => {
+    .then((res) => {
       const a = document.createElement("a");
-      a.href = URL.createObjectURL(playlistZip);
+      a.href = res["playlist_download_url"];
       a.download = `${plTitle}.zip`;
       a.click();
+      a.remove();
     })
     .finally(() => {
       Utils.hideLoading();

--- a/ytdl/main.py
+++ b/ytdl/main.py
@@ -2,12 +2,15 @@ from flask import Flask
 import os
 import signal
 from yt_dlp import YoutubeDL
+import shutil
 
-DOWNLOAD_PATH = os.environ.get("YOUTUBE_MUSIC_DOWNLOAD_PATH")
+DOWNLOAD_PATH = os.environ.get("BLOBS_DIR")
 if DOWNLOAD_PATH is None or DOWNLOAD_PATH == "":
-    print("Missing YOUTUBE_MUSIC_DOWNLOAD_PATH suka")
+    print("Missing BLOBS_DIR suka")
     exit(1)
 
+MUZIKKX_DIR = f"{DOWNLOAD_PATH}/muzikkx/"
+PIX_DIR = f"{DOWNLOAD_PATH}/pix/"
 
 YT_ERROR = {
     0: "none",
@@ -25,9 +28,11 @@ def download_yt_song(id: str) -> int:
                 "preferredcodec": "mp3",
                 "preferredquality": "192",
             }],
-            "outtmpl": f"{DOWNLOAD_PATH}/%(id)s.%(ext)s"
+            "writethumbnail": True,
+            "outtmpl": f"{MUZIKKX_DIR}/%(id)s.%(ext)s"
         })
         ytdl.download("https://www.youtube.com/watch?v=" + id)
+        shutil.move(f"{MUZIKKX_DIR}/{id}.webp", f"{PIX_DIR}/{id}.webp")
     except:
         return 3
     return 0


### PR DESCRIPTION
# Resurrection Release 🎉 🚀
DankMuzikk was fully functional and me and some users kept using it after [v0.1.53](https://github.com/mbaraa/dankmuzikk/releases/tag/v0.1.53), so I decided to do a make-over and probably finish the road map, and more...

## What happened here?
* Separated backend from frontend.
* Separated backend into smalled pieces {server, cdn, eventhub :eyes: and ytdl}.
* Introduced [EventHub](https://github.com/mbaraa/dankmuzikk/pull/104) for async operations, and to stop spamming the http handlers.
* Refactored most of the backend's code.
* Refactored some parts of the frontend's code.
* Removed weird download queue from the Python server, after the introduction of the EventHub.
* Fix deployment environments by having a docker compose generator that doesn't include the deployment compose files in git, which was possible after [this](https://github.com/mbaraa/rex-deploy/releases/tag/v1.6.4) update in [rex-deploy](https://github.com/mbaraa/rex-action).
* Fix playlist download unresponsiveness by moving the archive to the cdn then letting the browser handle the rest.
* Updated ytdlp
* With a plan to do moooore.

## PRs
* Dependencies fixes by @mbaraa in https://github.com/mbaraa/dankmuzikk/pull/102
* Separate Frontend from Backend by @mbaraa in https://github.com/mbaraa/dankmuzikk/pull/103
* Feat: Add Glorious Event Hub by @mbaraa in https://github.com/mbaraa/dankmuzikk/pull/104
* Fix: docker compose and deployments by @mbaraa in https://github.com/mbaraa/dankmuzikk/pull/105
* Feat/download thumbs to cdn by @mbaraa in https://github.com/mbaraa/dankmuzikk/pull/106
* Fix: playlist download from cdn by @mbaraa in https://github.com/mbaraa/dankmuzikk/pull/107
* refactor(blobs): add blobs storage interface by @mbaraa in https://github.com/mbaraa/dankmuzikk/pull/108


**Full Changelog**: https://github.com/mbaraa/dankmuzikk/compare/v0.1.53...v0.2.0